### PR TITLE
fix: alias error

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -20,6 +20,7 @@ export const guessIsType = (tsModule: typeof ts, typeChecker: ts.TypeChecker, sy
 
   // export { ex8, ex9 }
   if (tsModule.isExportSpecifier(declaration)) {
+    if (!(symbol.flags & tsModule.SymbolFlags.Alias)) return false
     const originalSymbol = typeChecker.getAliasedSymbol(symbol)
     if (!(originalSymbol.valueDeclaration ?? originalSymbol.declarations?.[0])) return false
     return guessIsType(tsModule, typeChecker, originalSymbol)
@@ -27,6 +28,7 @@ export const guessIsType = (tsModule: typeof ts, typeChecker: ts.TypeChecker, sy
 
   // export default ex10
   if (tsModule.isExportAssignment(declaration)) {
+    if (!(symbol.flags & tsModule.SymbolFlags.Alias)) return false
     const originalSymbol = typeChecker.getAliasedSymbol(symbol)
     if (!(originalSymbol.valueDeclaration ?? originalSymbol.declarations?.[0])) return false
     return guessIsType(tsModule, typeChecker, originalSymbol)

--- a/test/analyze.spec.ts
+++ b/test/analyze.spec.ts
@@ -1,0 +1,145 @@
+import { createRequire } from 'module'
+import { describe, expect, it } from 'vitest'
+import { guessIsType, analyzeExports } from '../src/analyze'
+import { getSingleFileProgram } from '../src/parser'
+
+const requireModule = createRequire(__filename)
+
+type TsModule = typeof import('typescript')
+
+const loadTypeScript = (specifier: string): TsModule =>
+  requireModule(specifier) as TsModule
+
+const typeScriptVariants: Array<{ label: string, ts: TsModule }> = [
+  { label: 'TypeScript 3.9', ts: loadTypeScript('typescript') },
+  { label: 'TypeScript 4.9', ts: loadTypeScript('typescript-4-9') },
+  { label: 'TypeScript 5.9', ts: loadTypeScript('typescript-5-9') }
+]
+
+const getExportsOf = (ts: TsModule, content: string, fileName = 'test.ts') => {
+  const fileProgram = getSingleFileProgram(ts, fileName, content)
+  const typeChecker = fileProgram.program.getTypeChecker()
+  const moduleSymbol = typeChecker.getSymbolAtLocation(fileProgram.ast)!
+  return { fileProgram, typeChecker, exports: moduleSymbol.exports! }
+}
+
+for (const { label, ts } of typeScriptVariants) {
+  describe(label, () => {
+    describe('guessIsType', () => {
+      describe('ExportAssignment (export default ...)', () => {
+        it('does not crash on export default object literal (non-alias)', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            import foo from './foo'
+            export default {
+              ...foo,
+              key: 'value'
+            } as const
+          `)
+          const defaultSymbol = exports.get('default' as ts.__String)!
+          expect(() => guessIsType(ts, typeChecker, defaultSymbol)).not.toThrow()
+        })
+
+        it('returns false for export default object literal (non-alias)', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            import foo from './foo'
+            export default {
+              ...foo,
+              key: 'value'
+            } as const
+          `)
+          const defaultSymbol = exports.get('default' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, defaultSymbol)).toBe(false)
+        })
+
+        it('returns false for export default variable reference (alias, not a type)', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            const locale = { key: 'value' } as const
+            export default locale
+          `)
+          const defaultSymbol = exports.get('default' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, defaultSymbol)).toBe(false)
+        })
+
+        it('returns true for export default type alias reference', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            type MyType = string
+            export default MyType
+          `)
+          const defaultSymbol = exports.get('default' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, defaultSymbol)).toBe(true)
+        })
+      })
+
+      describe('ExportSpecifier (export { X })', () => {
+        it('returns false for exported value', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            const foo = 1
+            export { foo }
+          `)
+          const fooSymbol = exports.get('foo' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, fooSymbol)).toBe(false)
+        })
+
+        it('returns true for exported type alias', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            type Foo = string
+            export { Foo }
+          `)
+          const fooSymbol = exports.get('Foo' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, fooSymbol)).toBe(true)
+        })
+
+        it('returns true for exported interface', () => {
+          const { typeChecker, exports } = getExportsOf(ts, `
+            interface Bar { x: number }
+            export { Bar }
+          `)
+          const barSymbol = exports.get('Bar' as ts.__String)!
+          expect(guessIsType(ts, typeChecker, barSymbol)).toBe(true)
+        })
+      })
+    })
+
+    describe('analyzeExports', () => {
+      it('does not crash on file with export default object literal', () => {
+        const content = `
+          import common from './common.json'
+          import extra from './extra.json'
+          export default {
+            ...common,
+            ...extra
+          } as const
+        `
+        const fileProgram = getSingleFileProgram(ts, 'locale.ts', content)
+        expect(() => analyzeExports(ts, fileProgram, null)).not.toThrow()
+      })
+
+      it('marks export default object literal as non-type', () => {
+        const content = `
+          import common from './common.json'
+          export default {
+            ...common,
+            key: 'value'
+          } as const
+        `
+        const fileProgram = getSingleFileProgram(ts, 'locale.ts', content)
+        const result = analyzeExports(ts, fileProgram, null)
+        const defaultExport = result.find(e => e.default)
+        expect(defaultExport).toBeDefined()
+        expect(defaultExport!.isTypeOnly).toBe(false)
+      })
+
+      it('marks export default variable as non-type', () => {
+        const content = `
+          const locale = { key: 'value' } as const
+          export default locale
+        `
+        const fileProgram = getSingleFileProgram(ts, 'locale.ts', content)
+        const result = analyzeExports(ts, fileProgram, null)
+        const defaultExport = result.find(e => e.default)
+        expect(defaultExport).toBeDefined()
+        expect(defaultExport!.isTypeOnly).toBe(false)
+      })
+    })
+  })
+}


### PR DESCRIPTION
跑 export-index-generator 假設碰到這類檔案內容

```
import common from './zh-CN/common.json'
import component from './zh-CN/component.json'

export default {
  ...common,
  ...component
} as const
```

會直接 Error

```
Error: Debug Failure. False expression: Should only get Alias here.
    at Object.resolveAlias [as getAliasedSymbol] (typescript.js)
    at guessIsType (analyze.js:28)
    at analyzeExports (analyze.js:62)
```

## 根本原因

`guessIsType` 函式在 `ExportSpecifier` 和 `ExportAssignment` 兩個分支中，皆無條件地呼叫 `typeChecker.getAliasedSymbol(symbol)`：

```ts
// export { ex8, ex9 }
if (tsModule.isExportSpecifier(declaration)) {
  const originalSymbol = typeChecker.getAliasedSymbol(symbol) // 💥 無防護檢查
  ...
}

// export default ex10
if (tsModule.isExportAssignment(declaration)) {
  const originalSymbol = typeChecker.getAliasedSymbol(symbol) // 💥 無防護檢查
  ...
}
```

TypeScript 的 `getAliasedSymbol` 內部有 assert：`symbol.flags & SymbolFlags.Alias`。

由於工具以單一檔案模式（`noResolve: true`）建立 TypeScript program，在此環境下 `export default { ...spread }` 產生的 `ExportAssignment`，其 `default` symbol **不是 alias**——它直接代表物件字面量本身。對這類 symbol 呼叫 `getAliasedSymbol` 就會觸發 assert 並拋出錯誤。

## 修正方式

在兩個分支呼叫 `getAliasedSymbol` 前，加入 `SymbolFlags.Alias` 的防護檢查。若 symbol 不是 alias，直接 `return false`（非 type-only export）：

```ts
// export { ex8, ex9 }
if (tsModule.isExportSpecifier(declaration)) {
  if (!(symbol.flags & tsModule.SymbolFlags.Alias)) return false
  const originalSymbol = typeChecker.getAliasedSymbol(symbol)
  ...
}

// export default ex10
if (tsModule.isExportAssignment(declaration)) {
  if (!(symbol.flags & tsModule.SymbolFlags.Alias)) return false
  const originalSymbol = typeChecker.getAliasedSymbol(symbol)
  ...
}
```

## 測試

新增 `test/analyze.spec.ts`，針對 `guessIsType` 與 `analyzeExports` 進行單元測試，已在本地跑過 `pnpm test` 全數通過